### PR TITLE
Exec multiple

### DIFF
--- a/threads/thread.c
+++ b/threads/thread.c
@@ -579,7 +579,7 @@ allocate_tid (void)
   lock_acquire (&tid_lock);
   tid = next_tid++;
   lock_release (&tid_lock);
-  printf("**** adding new tid %d\n", tid);
+  //printf("**** adding new tid %d\n", tid);
 
   return tid;
 }
@@ -590,38 +590,20 @@ uint32_t thread_stack_ofs = offsetof (struct thread, stack);
 
 struct thread* get_thread_by_tid(tid_t child_tid)
 {
-//  struct list_elem *e;
-//
-//  int count = 0;
-//  e = list_begin (&all_list);
-//  while(e != list_end (&all_list) && e->next != NULL)
-//  {
-//
-//    struct thread *t = list_entry (e, struct thread, elem);
-//    printf("get_thread_by_tid[%d]: {%s} comparing %d to %d\n", count++, t->name, t->tid, child_tid);
-//    if (t->tid == child_tid)
-//    {
-//      printf("***** we found the thread for the tid %d:\n", t->tid);
-//      return t;
-//    }
-//
-//    e = list_next (e);
-//  }
 
   struct list_elem *e;
   for (e = list_begin (&all_list); e != list_end (&all_list); e = list_next (e))
   {
     int count = 0;
     struct thread *t = list_entry (e, struct thread, allelem);
-    printf("get_thread_by_tid[%d]: {%s} comparing %d to %d\n", count++, t->name, t->tid, child_tid);
+    //printf("get_thread_by_tid[%d]: {%s} comparing %d to %d\n", count++, t->name, t->tid, child_tid);
     if (t->tid == child_tid)
     {
-      printf("***** we found the thread for the tid %d:\n", t->tid);
+      //printf("***** we found the thread for the tid %d:\n", t->tid);
       return t;
     }
   }
 
-  printf("asdfasdfasdf\n");
   return NULL;
 }
 

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -198,15 +198,6 @@ thread_create (const char *name, int priority,
   sf->eip = switch_entry;
   sf->ebp = 0;
 
-  // Init semaphores
-  if (&(t->about_to_die_sem) == NULL) {
-    sema_init(&(t->about_to_die_sem), 0);
-  }
-
-  if (&(t->can_die_now_sem) == NULL){
-    sema_init(&(t->can_die_now_sem), 0);
-  }
-
   /* Add to run queue. */
   thread_unblock (t);
 
@@ -476,6 +467,10 @@ init_thread (struct thread *t, const char *name, int priority)
   old_level = intr_disable ();
   list_push_back (&all_list, &t->allelem);
   intr_set_level (old_level);
+
+  sema_init(&(t->about_to_die_sem), 0);
+  sema_init(&(t->can_die_now_sem), 0);
+
 }
 
 /* Allocates a SIZE-byte frame at the top of thread T's stack and
@@ -584,6 +579,7 @@ allocate_tid (void)
   lock_acquire (&tid_lock);
   tid = next_tid++;
   lock_release (&tid_lock);
+  printf("**** adding new tid %d\n", tid);
 
   return tid;
 }
@@ -591,3 +587,43 @@ allocate_tid (void)
 /* Offset of `stack' member within `struct thread'.
    Used by switch.S, which can't figure it out on its own. */
 uint32_t thread_stack_ofs = offsetof (struct thread, stack);
+
+struct thread* get_thread_by_tid(tid_t child_tid)
+{
+//  struct list_elem *e;
+//
+//  int count = 0;
+//  e = list_begin (&all_list);
+//  while(e != list_end (&all_list) && e->next != NULL)
+//  {
+//
+//    struct thread *t = list_entry (e, struct thread, elem);
+//    printf("get_thread_by_tid[%d]: {%s} comparing %d to %d\n", count++, t->name, t->tid, child_tid);
+//    if (t->tid == child_tid)
+//    {
+//      printf("***** we found the thread for the tid %d:\n", t->tid);
+//      return t;
+//    }
+//
+//    e = list_next (e);
+//  }
+
+  struct list_elem *e;
+  for (e = list_begin (&all_list); e != list_end (&all_list); e = list_next (e))
+  {
+    int count = 0;
+    struct thread *t = list_entry (e, struct thread, allelem);
+    printf("get_thread_by_tid[%d]: {%s} comparing %d to %d\n", count++, t->name, t->tid, child_tid);
+    if (t->tid == child_tid)
+    {
+      printf("***** we found the thread for the tid %d:\n", t->tid);
+      return t;
+    }
+  }
+
+  printf("asdfasdfasdf\n");
+  return NULL;
+}
+
+
+

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -198,6 +198,15 @@ thread_create (const char *name, int priority,
   sf->eip = switch_entry;
   sf->ebp = 0;
 
+  // Init semaphores
+  if (&(t->about_to_die_sem) == NULL) {
+    sema_init(&(t->about_to_die_sem), 0);
+  }
+
+  if (&(t->can_die_now_sem) == NULL){
+    sema_init(&(t->can_die_now_sem), 0);
+  }
+
   /* Add to run queue. */
   thread_unblock (t);
 

--- a/threads/thread.h
+++ b/threads/thread.h
@@ -141,4 +141,7 @@ void thread_set_nice (int);
 int thread_get_recent_cpu (void);
 int thread_get_load_avg (void);
 
+struct list get_all_list(void);
+struct thread* get_thread_by_tid(tid_t child_tid);
+
 #endif /* threads/thread.h */

--- a/threads/thread.h
+++ b/threads/thread.h
@@ -4,6 +4,7 @@
 #include <debug.h>
 #include <list.h>
 #include <stdint.h>
+#include "threads/synch.h"
 
 /* States in a thread's life cycle. */
 enum thread_status
@@ -89,6 +90,8 @@ struct thread
     uint8_t *stack;                     /* Saved stack pointer. */
     int priority;                       /* Priority. */
     struct list_elem allelem;           /* List element for all threads list. */
+    struct semaphore about_to_die_sem;
+    struct semaphore can_die_now_sem;
 
     /* Shared between thread.c and synch.c. */
     struct list_elem elem;              /* List element. */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -139,14 +139,23 @@ volatile int child_done = 0;
 int
 process_wait (tid_t child_tid UNUSED) 
 {
-   while(!child_done){}
-  //sema_down()
+  // while(!child_done){}
 
-  // sema_down(&about2die);
-  // read child status -- get this from the list of childs
-  // sema_up($can_die_now)
-  // return;
-    return -1;
+  // get the thread struct with the child_tid
+//  struct thread *cur = thread_current ();
+//  printf("process_wait() passed in tid %d\n", child_tid);
+//  printf("process_wait() thread-current() has (parent) tid of %d\n", cur->tid);
+
+  struct thread *found_thread = get_thread_by_tid(child_tid);
+
+  sema_down(&(found_thread->about_to_die_sem));
+
+  //int exit_status = found_thread->status;
+  //sema_up(&(found_thread->can_die_now_sem));
+
+  //return exit_status;
+  return -1;
+
 }
 
 /* Free the current process's resources. */
@@ -156,9 +165,9 @@ process_exit (void)
   struct thread *cur = thread_current ();
   uint32_t *pd;
 
-  child_done = 1;
-  // sema_up(&about2die)
-  // sema_down(&can_die_now)
+  //child_done = 1;
+  sema_up(&(cur->about_to_die_sem));
+  //sema_down(&(cur->can_die_now_sem));
 
   /* Destroy the current process's page directory and switch back
      to the kernel-only page directory. */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -72,11 +72,11 @@ process_execute (const char *cmd_string)
  
 
   /* Create a new thread to execute FILE_NAME. */
-  printf("1 process_execute() about to thread_create for %s\n", child.args[0].name);
+  //printf("1 process_execute() about to thread_create for %s\n", child.args[0].name);
   tid = thread_create (child.args[0].name, PRI_DEFAULT, start_process, &child);
-  printf("2-3 process_execute() waiting for child to finish...\n");
+  //printf("2-3 process_execute() waiting for child to finish...\n");
   //sema_down(&sem);
-  printf("5 process_execute() after sema_down\n");
+  //printf("5 process_execute() after sema_down\n");
   if (tid == TID_ERROR)
     palloc_free_page (cmd_copy); 
   return tid;
@@ -87,7 +87,7 @@ process_execute (const char *cmd_string)
 static void
 start_process (void *childptr)
 {
-  printf("2-3 start_process() entered with\n");
+  //printf("2-3 start_process() entered with\n");
   child_t *child = (child_t *)childptr;
   struct intr_frame if_;
   bool success;
@@ -114,7 +114,7 @@ start_process (void *childptr)
       thread_exit();
 
 
-  printf("4 start_process() called sema_up\n");
+  //printf("4 start_process() called sema_up\n");
   
   /* Start the user process by simulating a return from an
      interrupt, implemented by intr_exit (in


### PR DESCRIPTION
exec-once and exec-multiple pass

pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/sc-bad-sp
FAIL tests/userprog/sc-bad-arg
pass tests/userprog/sc-boundary
pass tests/userprog/sc-boundary-2
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-stdin
pass tests/userprog/close-stdout
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-multiple
FAIL tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
FAIL tests/userprog/wait-simple
FAIL tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
FAIL tests/userprog/multi-recurse
FAIL tests/userprog/multi-child-fd
FAIL tests/userprog/rox-simple
FAIL tests/userprog/rox-child
FAIL tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
FAIL tests/userprog/no-vm/multi-oom
pass tests/filesys/base/lg-create
FAIL tests/filesys/base/lg-full
FAIL tests/filesys/base/lg-random
FAIL tests/filesys/base/lg-seq-block
FAIL tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
FAIL tests/filesys/base/sm-full
FAIL tests/filesys/base/sm-random
FAIL tests/filesys/base/sm-seq-block
FAIL tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
FAIL tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
21 of 76 tests failed.
