### PR TITLE
Apt sem work

### DIFF
--- a/threads/thread.c
+++ b/threads/thread.c
@@ -470,6 +470,7 @@ init_thread (struct thread *t, const char *name, int priority)
 
   sema_init(&(t->about_to_die_sem), 0);
   sema_init(&(t->can_die_now_sem), 0);
+  t->num_children = 0;
 
 }
 

--- a/threads/thread.h
+++ b/threads/thread.h
@@ -92,6 +92,10 @@ struct thread
     struct list_elem allelem;           /* List element for all threads list. */
     struct semaphore about_to_die_sem;
     struct semaphore can_die_now_sem;
+    tid_t children[100];
+    int num_children;
+    tid_t parent;
+    int exit_status;
 
     /* Shared between thread.c and synch.c. */
     struct list_elem elem;              /* List element. */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -70,11 +70,14 @@ process_execute (const char *cmd_string)
   child.argc = i;
   child.child_wait_sem = sem;
 
- 
+  struct thread *cur = thread_current ();
 
   /* Create a new thread to execute FILE_NAME. */
   //printf("1 process_execute() about to thread_create for %s\n", child.args[0].name);
   tid = thread_create (child.args[0].name, PRI_DEFAULT, start_process, &child);
+  cur->children[cur->num_children] = tid;
+  //printf("we have just added %d to the child list of this parent\n", tid);
+  cur->num_children = cur->num_children + 1;
   //printf("2-3 process_execute() waiting for child to finish...\n");
   sema_down(sem); //[semaphore set 1]
   //printf("5 process_execute() after sema_down\n");
@@ -146,18 +149,62 @@ process_wait (tid_t child_tid UNUSED)
   // while(!child_done){}
 
   // get the thread struct with the child_tid
-//  struct thread *cur = thread_current ();
+   struct thread *parent_thread = thread_current ();
 //  printf("process_wait() passed in tid %d\n", child_tid);
 //  printf("process_wait() thread-current() has (parent) tid of %d\n", cur->tid);
 
+
+
   struct thread *found_thread = get_thread_by_tid(child_tid);
+
+  // TODO: We should not wait here unless this parent is actually waiting on
+  // THIS child (child_tid)
+  // If this is NOT waiting on this child, then return -1
+
+  bool is_parent_waiting_on_child = false;
+  int i = 0;
+  tid_t all_children[100];
+
+  for (int j = 0; j < 100; j++)
+  {
+    all_children[j] = parent_thread->children[j];
+  }
+
+
+  for (i= 0; i < parent_thread->num_children; i++)
+  {
+    //printf("checking if %d==%d\n", all_children[i], child_tid);
+    if (all_children[i] == child_tid)
+    {
+      is_parent_waiting_on_child = true;
+      break;
+    }
+  }
+
+  if (!is_parent_waiting_on_child)
+  {
+    //printf("asdfasdfasdfasdfafsd\n");
+    return -1;
+  }
 
   sema_down(&(found_thread->about_to_die_sem)); // [semaphore set 2] basic wait functionality
 
-//  int exit_status = found_thread->status;
+  int exit_status = found_thread->exit_status;
 //  printf("Exit status is %d", exit_status);
 //  printf("Enum found_thread->status is %d", (int)(found_thread->status));
   sema_up(&(found_thread->can_die_now_sem));  // [semaphore set 3] getting status
+
+  // this child is about to die, remove it from the parent's children list
+  for (i= 0; i < parent_thread->num_children; i++)
+  {
+    //printf("checking if %d==%d\n", all_children[i], child_tid);
+    if (all_children[i] == child_tid)
+    {
+      parent_thread->children[i] = -100;
+      break;
+    }
+  }
+
 
   return -1;
   //return exit_status;

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -206,7 +206,8 @@ process_wait (tid_t child_tid UNUSED)
   }
 
 
-  return -1;
+  return found_thread->exit_status;
+  //return -1;
   //return exit_status;
 
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -59,7 +59,7 @@ void sys_halt (void){
 void sys_exit (int status){
 
     printf("%s: exit(%d)\n",thread_name(),status);
-    thread *cur = thread_current();
+    struct thread *cur = thread_current();
     cur->exit_status = status;
     thread_exit();
 

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -59,6 +59,8 @@ void sys_halt (void){
 void sys_exit (int status){
 
     printf("%s: exit(%d)\n",thread_name(),status);
+    thread *cur = thread_current();
+    cur->exit_status = status;
     thread_exit();
 
 }


### PR DESCRIPTION
wait-simple, wait-twice, wait-bad- multi-recurse,

pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/sc-bad-sp
FAIL tests/userprog/sc-bad-arg
pass tests/userprog/sc-boundary
pass tests/userprog/sc-boundary-2
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-stdin
pass tests/userprog/close-stdout
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-multiple
FAIL tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
FAIL tests/userprog/multi-child-fd
FAIL tests/userprog/rox-simple
FAIL tests/userprog/rox-child
FAIL tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
FAIL tests/userprog/no-vm/multi-oom
pass tests/filesys/base/lg-create
FAIL tests/filesys/base/lg-full
FAIL tests/filesys/base/lg-random
FAIL tests/filesys/base/lg-seq-block
FAIL tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
FAIL tests/filesys/base/sm-full
FAIL tests/filesys/base/sm-random
FAIL tests/filesys/base/sm-seq-block
FAIL tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
FAIL tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
18 of 76 tests failed.
