### PR TITLE
Filesys locks

### DIFF
--- a/tests/userprog/no-vm/Make.tests
+++ b/tests/userprog/no-vm/Make.tests
@@ -5,4 +5,4 @@ tests/userprog/no-vm_PROGS = $(tests/userprog/no-vm_TESTS)
 tests/userprog/no-vm/multi-oom_SRC = tests/userprog/no-vm/multi-oom.c	\
 tests/lib.c
 
-tests/userprog/no-vm/multi-oom.output: TIMEOUT = 360
+tests/userprog/no-vm/multi-oom.output: TIMEOUT = 1

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -223,9 +223,13 @@ int sys_open (const char *file){
 /*    Returns the size, in bytes, of the file open as fd. 
  */
 int sys_filesize (int fd){
+  int ret_val = 0;
     //printf("***** Called sys_filesize but it is not yet implemented.\n");
     struct file* found_file = get_file_from_fd(fd);
-    return file_length(found_file);
+  lock_acquire (&lock);
+    ret_val = file_length(found_file);
+  lock_release (&lock);
+  return ret_val;
 }
 /*
     Reads size bytes from the file open as fd into buffer. Returns the number of bytes
@@ -306,7 +310,9 @@ int sys_write (int fd, const void *buffer, unsigned size){
 void sys_seek (int fd, unsigned position){
     //printf("***** Called sys_seek but it is not yet implemented.\n");
   struct file *found_file = get_file_from_fd(fd);
+  lock_acquire (&lock);
   file_seek(found_file, position);
+  lock_release (&lock);
 }
 
 /*

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -49,7 +49,8 @@ syscall_handler (struct intr_frame *f UNUSED)
       "threads/init.h"). This should be seldom used, because you lose
       some information about possible deadlock situations, etc. */
 void sys_halt (void){
-    printf("***** Called sys_halt but it is not yet implemented.\n");
+    //printf("***** Called sys_halt but it is not yet implemented.\n");
+  shutdown_power_off();
 }
 
 /*    Terminates the current user program, returning status to the
@@ -300,7 +301,9 @@ int sys_write (int fd, const void *buffer, unsigned size){
 */
 
 void sys_seek (int fd, unsigned position){
-    printf("***** Called sys_seek but it is not yet implemented.\n");
+    //printf("***** Called sys_seek but it is not yet implemented.\n");
+  struct file *found_file = get_file_from_fd(fd);
+  file_seek(found_file, position);
 }
 
 /*
@@ -308,7 +311,13 @@ void sys_seek (int fd, unsigned position){
     open file fd, expressed in bytes from the beginning of the file.
 */
 unsigned sys_tell (int fd){
-    printf("***** Called sys_tell but it is not yet implemented.\n");
+    //printf("***** Called sys_tell but it is not yet implemented.\n");
+  struct file *found_file = get_file_from_fd(fd);
+  unsigned  ret_val = 0;
+
+  lock_acquire (&lock);
+  ret_val = file_tell(found_file);
+  lock_release (&lock);
 }
     
 /*

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -163,9 +163,12 @@ bool sys_create (const char *file, unsigned initial_size) {
     Removing an Open File, for details.
 */
 bool sys_remove (const char *file){
+  bool ret_val = false;
   lock_acquire (&lock);
-    filesys_remove(file);
+   ret_val = filesys_remove(file);
   lock_release (&lock);
+
+  return ret_val;
 }
 
 /*    Opens the file called file. Returns a nonnegative integer handle
@@ -318,6 +321,8 @@ unsigned sys_tell (int fd){
   lock_acquire (&lock);
   ret_val = file_tell(found_file);
   lock_release (&lock);
+
+  return ret_val;
 }
     
 /*


### PR DESCRIPTION
Fixes lg-random, sm-random, syn-remove

pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/sc-bad-sp
FAIL tests/userprog/sc-bad-arg
pass tests/userprog/sc-boundary
pass tests/userprog/sc-boundary-2
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-stdin
pass tests/userprog/close-stdout
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-multiple
FAIL tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
FAIL tests/userprog/multi-child-fd
FAIL tests/userprog/rox-simple
FAIL tests/userprog/rox-child
FAIL tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
FAIL tests/userprog/no-vm/multi-oom
pass tests/filesys/base/lg-create
FAIL tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
FAIL tests/filesys/base/lg-seq-block
FAIL tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
FAIL tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
FAIL tests/filesys/base/sm-seq-block
FAIL tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
15 of 76 tests failed.
