### PR TITLE
Rox child

### DIFF
--- a/threads/thread.h
+++ b/threads/thread.h
@@ -96,6 +96,7 @@ struct thread
     int num_children;
     tid_t parent;
     int exit_status;
+    struct file *file;
 
     /* Shared between thread.c and synch.c. */
     struct list_elem elem;              /* List element. */

--- a/threads/thread.h
+++ b/threads/thread.h
@@ -97,6 +97,7 @@ struct thread
     tid_t parent;
     int exit_status;
     struct file *file;
+    int fd;
 
     /* Shared between thread.c and synch.c. */
     struct list_elem elem;              /* List element. */

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -79,7 +79,7 @@ void sys_exit (int status){
 
 pid_t sys_exec (const char *cmd_line){
     struct thread *cur = thread_current();
-    if (cur->file != NULL) {
+    if (cur->file != NULL && cur->fd >= 100) {
         file_deny_write(cur->file);
     }
     return process_execute(cmd_line);
@@ -299,7 +299,7 @@ int sys_write (int fd, const void *buffer, unsigned size) {
         struct thread *cur = thread_current();
 
         lock_acquire(&lock);
-        if (cur->fd == fd)
+        if (cur->fd == fd && fd >= 100)
         {
             file_allow_write(found_file);
         }


### PR DESCRIPTION
Fixes rox-child, rox-multichild

pass tests/filesys/base/syn-write
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/sc-bad-sp
FAIL tests/userprog/sc-bad-arg
pass tests/userprog/sc-boundary
pass tests/userprog/sc-boundary-2
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-stdin
pass tests/userprog/close-stdout
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-multiple
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
FAIL tests/userprog/multi-child-fd
FAIL tests/userprog/rox-simple
pass tests/userprog/rox-child
pass tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
FAIL tests/userprog/no-vm/multi-oom
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
pass tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
pass tests/filesys/base/syn-write
4 of 76 tests failed.
